### PR TITLE
Fix KeyError: 'api_keys' when running evo research, or olas make_prediction

### DIFF
--- a/evo_researcher/autonolas/research.py
+++ b/evo_researcher/autonolas/research.py
@@ -1126,7 +1126,7 @@ def research(
     
 
 def make_prediction(prompt: str, additional_information: str, **kwargs) -> Prediction:
-    api_keys: dict[str, str] = kwargs["api_keys"]
+    api_keys: dict[str, str] = kwargs.get("api_keys", {})
     open_ai_key = api_keys.get('openai', os.getenv("OPENAI_API_KEY"))
     
     current_time_utc = datetime.now(timezone.utc)

--- a/evo_researcher/functions/research.py
+++ b/evo_researcher/functions/research.py
@@ -9,7 +9,7 @@ from evo_researcher.functions.scrape_results import scrape_results
 from evo_researcher.functions.search import search
 
 def research(goal: str, **kwargs) -> tuple[str, str]:
-    api_keys: dict[str, str] = kwargs["api_keys"]
+    api_keys: dict[str, str] = kwargs.get("api_keys", {})
     open_ai_key = api_keys.get('openai', os.getenv("OPENAI_API_KEY"))
     tavily_key = api_keys.get('tavily', os.getenv("TAVILY_API_KEY"))
     


### PR DESCRIPTION
On main, if I do either `python ./evo_researcher/main.py research "foo" evo` or `python ./evo_researcher/main.py predict "foo" ./outputs/...` I get:

```
    api_keys: dict[str, str] = kwargs["api_keys"]
KeyError: 'api_keys'
```

Looks like the issue cam from https://github.com/polywrap/evo.researcher/commit/4b2017b9fec7162698f3d14a212b751dc8cc0b89