### PR TITLE
Fix calls to langchain API inside autolonas' fetch_additional_information method

### DIFF
--- a/evo_researcher/autonolas/research.py
+++ b/evo_researcher/autonolas/research.py
@@ -1030,8 +1030,8 @@ def fetch_additional_information(
 
     # Create messages for the OpenAI engine
     messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": url_query_prompt},
+        ("system", "You are a helpful assistant."),
+        ("user", url_query_prompt),
     ]
 
     # Fetch queries from the OpenAI engine
@@ -1040,7 +1040,6 @@ def fetch_additional_information(
         research_prompt |
         ChatOpenAI(
             model=engine,
-            messages=messages,
             temperature=temperature,
             max_tokens=max_compl_tokens,
             n=1, timeout=90,
@@ -1048,7 +1047,7 @@ def fetch_additional_information(
         ) |
         StrOutputParser()
     )
-    response = research_chain.invoke()
+    response = research_chain.invoke({})
 
     # Parse the response content
     json_data = json.loads(response)


### PR DESCRIPTION
The commit: https://github.com/polywrap/evo.researcher/commit/c8ec11692f79c542ff2be2ae52786de8dd6995fc

breaks the autolonas research function:
```
python ./evo_researcher/main.py research "A test" autonolas
```

The failure is inside evo_researcher/autonolas/research.py from the call:
```
research_prompt = ChatPromptTemplate.from_messages(messages=messages)
```
with the error
```
NotImplementedError: Unsupported message type: <class 'dict'>
```

This PR fixes this issue